### PR TITLE
v1.10.2: Fix HitboxModule destruction caused by the 2025.11.04 game patch changes

### DIFF
--- a/Source/DebugModPlus.cs
+++ b/Source/DebugModPlus.cs
@@ -183,6 +183,8 @@ public class DebugModPlus : BaseUnityPlugin {
 
             RCGLifeCycle.DontDestroyForever(gameObject);
             RCGLifeCycle.DontDestroyForever(HitboxModule.gameObject);
+            gameObject.hideFlags = HideFlags.HideAndDontSave;
+            HitboxModule.gameObject.hideFlags = HideFlags.HideAndDontSave;
 
             QuantumConsoleModule.Initialize();
 

--- a/Source/DebugModPlus.csproj
+++ b/Source/DebugModPlus.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>DebugModPlus</AssemblyName>
         <Description>Advanced Debug Mod for Nine Sols</Description>
         <TargetFramework>netstandard2.1</TargetFramework>
-        <Version>1.10.1</Version>
+        <Version>1.10.2</Version>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <LangVersion>latest</LangVersion>
         <NoWarn>MSB3277;CS0162</NoWarn>

--- a/thunderstore/thunderstore.toml
+++ b/thunderstore/thunderstore.toml
@@ -4,7 +4,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "jakobhellermann"
 name = "DebugMod"
-versionNumber = "1.10.1"
+versionNumber = "1.10.2"
 description = "Debug tools for the game"
 websiteUrl = "https://github.com/jakobhellermann/NineSols-DebugMod"
 containsNsfwContent = false


### PR DESCRIPTION
Applied HideAndDontSave hide flag to the mod and the HitboxModule game objects to prevent their destruction.